### PR TITLE
fix: address pollen card review issues (Copilot review #102)

### DIFF
--- a/src/cards/pollen/pollen-card-editor.ts
+++ b/src/cards/pollen/pollen-card-editor.ts
@@ -53,6 +53,11 @@ export class PollenCardEditor extends LitElement implements LovelaceCardEditor {
         background: var(--secondary-background-color, rgba(0, 0, 0, 0.04));
         cursor: pointer;
         user-select: none;
+        width: 100%;
+        border: none;
+        text-align: left;
+        color: inherit;
+        font: inherit;
       }
       .pollen-type-name {
         font-size: 14px;
@@ -100,14 +105,14 @@ export class PollenCardEditor extends LitElement implements LovelaceCardEditor {
 
     return html`
       <div class="pollen-type-block">
-        <div class="pollen-type-header" @click=${() => this._toggleType(type, !enabled)}>
+        <button class="pollen-type-header" @click=${() => this._toggleType(type, !enabled)}>
           <span class="pollen-type-name">${_t(`pollen.types.${type}`)}</span>
           <ha-switch
             .checked=${enabled}
             @click=${(e: Event) => e.stopPropagation()}
             @change=${(e: Event) => this._toggleType(type, (e.target as HTMLInputElement).checked)}
           ></ha-switch>
-        </div>
+        </button>
         ${enabled
           ? html`
               <div class="pollen-type-fields">

--- a/src/cards/pollen/pollen-card-editor.ts
+++ b/src/cards/pollen/pollen-card-editor.ts
@@ -51,11 +51,15 @@ export class PollenCardEditor extends LitElement implements LovelaceCardEditor {
         justify-content: space-between;
         padding: 10px 14px;
         background: var(--secondary-background-color, rgba(0, 0, 0, 0.04));
-        cursor: pointer;
         user-select: none;
-        width: 100%;
+      }
+      .pollen-type-toggle {
+        background: none;
         border: none;
+        padding: 0;
+        flex: 1;
         text-align: left;
+        cursor: pointer;
         color: inherit;
         font: inherit;
       }
@@ -105,14 +109,15 @@ export class PollenCardEditor extends LitElement implements LovelaceCardEditor {
 
     return html`
       <div class="pollen-type-block">
-        <button class="pollen-type-header" @click=${() => this._toggleType(type, !enabled)}>
-          <span class="pollen-type-name">${_t(`pollen.types.${type}`)}</span>
+        <div class="pollen-type-header">
+          <button class="pollen-type-toggle" @click=${() => this._toggleType(type, !enabled)}>
+            <span class="pollen-type-name">${_t(`pollen.types.${type}`)}</span>
+          </button>
           <ha-switch
             .checked=${enabled}
-            @click=${(e: Event) => e.stopPropagation()}
             @change=${(e: Event) => this._toggleType(type, (e.target as HTMLInputElement).checked)}
           ></ha-switch>
-        </button>
+        </div>
         ${enabled
           ? html`
               <div class="pollen-type-fields">

--- a/src/cards/pollen/pollen-card.ts
+++ b/src/cards/pollen/pollen-card.ts
@@ -69,6 +69,13 @@ export class PollenCard extends LitElement {
         justify-content: space-between;
         cursor: pointer;
         user-select: none;
+        background: none;
+        border: none;
+        padding: 0;
+        width: 100%;
+        text-align: left;
+        color: inherit;
+        font: inherit;
       }
 
       .header-left {
@@ -204,7 +211,10 @@ export class PollenCard extends LitElement {
       unit?: string;
     }> = [];
 
-    let anyEntityConfigured = false;
+    // Check across ALL types (including disabled) whether any entity is configured
+    const anyEntityConfigured = POLLEN_TYPES.some(
+      t => !!(this.config[`${t}_entity` as keyof PollenCardConfig] as string | undefined)
+    );
 
     for (const type of POLLEN_TYPES) {
       const enabled = this.config[`${type}_enabled` as keyof PollenCardConfig];
@@ -213,7 +223,6 @@ export class PollenCard extends LitElement {
       const entityId = this.config[`${type}_entity` as keyof PollenCardConfig] as
         | string
         | undefined;
-      if (entityId) anyEntityConfigured = true;
 
       const levelEntity = this._getEntityState(entityId);
       if (!levelEntity) continue;
@@ -239,7 +248,7 @@ export class PollenCard extends LitElement {
     const overallColor = LEVEL_COLOR[overall];
 
     return html`
-      <div class="header" @click=${this._toggle}>
+      <button class="header" @click=${this._toggle} aria-expanded=${this._expanded}>
         <div class="header-left">
           <span class="title">🌿 ${_t('pollen.title')}</span>
           <span class="overall-badge" style="background: ${overallColor};">
@@ -247,7 +256,7 @@ export class PollenCard extends LitElement {
           </span>
         </div>
         <span class="chevron ${this._expanded ? 'open' : ''}">⌄</span>
-      </div>
+      </button>
 
       ${this._expanded
         ? html`

--- a/src/utils/warning-renderer.ts
+++ b/src/utils/warning-renderer.ts
@@ -68,7 +68,7 @@ export function renderRankedSlot(
           ${effectiveAdditional > 0
             ? html`<span
                 style="font-size: 12px; opacity: 0.75;"
-                title="${_t('warnings_additional', { count: effectiveAdditional })}"
+                title="${_t('warning.warnings_additional', { count: effectiveAdditional })}"
               >
                 +${effectiveAdditional}
               </span>`


### PR DESCRIPTION
Fixes 4 issues raised in the Copilot review of PR #102.

### Fixes

**`warning-renderer.ts` — wrong translation key for "+N more" badge**
`_t('warnings_additional')` → `_t('warning.warnings_additional')` after the translation namespace refactor in 1.9.0. Without this fix the badge renders the raw key name instead of the translated string.

**`pollen-card.ts` — empty-state message logic was inverted**
`anyEntityConfigured` was computed inside the enabled-type loop, so a card with all types intentionally disabled would show "not configured" instead of nothing meaningful, and a card with entities configured but all unavailable would show "no data" correctly — but the two states were swapped for edge cases. Now `anyEntityConfigured` is computed across _all_ types before the enabled filter.

**`pollen-card.ts` — expand/collapse header: `div` → `button`**
Added `button` semantics and `aria-expanded` so keyboard users can toggle the detail grid.

**`pollen-card-editor.ts` — pollen-type header: `div` → `button`**
Same fix for the per-type section header in the Visual Editor.