### PR TITLE
fix: update GitHub Actions to Node.js 24 and CodeQL v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: CodeQL
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     branches: [ main, develop ]
@@ -22,10 +25,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: javascript-typescript
         config-file: ./.github/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     tags:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: HACS Action
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
## Summary

Fixes deprecation warnings appearing in GitHub Actions runs.

### Changes

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` as top-level `env` to all 4 workflow files (`ci.yml`, `release.yml`, `validate.yml`, `codeql.yml`)
- Update `github/codeql-action/init` and `github/codeql-action/analyze` from `v3` to `v4` in `codeql.yml`

### Background

- Node.js 20 actions will be forced to Node.js 24 by default starting **June 2, 2026**
- Node.js 20 will be removed from runners on **September 16, 2026**
- CodeQL Action v3 will be deprecated in **December 2026**